### PR TITLE
Fixing led path

### DIFF
--- a/lib/leds.ex
+++ b/lib/leds.ex
@@ -8,7 +8,7 @@ defmodule Leds do
 
   """
 
-  @sys_leds_path "/sys/class/leds"
+  @sys_leds_path "/sys/class/leds/"
 
   @name_map  Application.get_env :leds, :name_map, []
 


### PR DESCRIPTION
There was an issue in the creation of led path. The '/' was missing in concatenation which caused it to create a path list /sys/class/ledsled0/... which is incorrect. Added the required '/' in the sys_leds_path
